### PR TITLE
Add Assertions

### DIFF
--- a/src/main/java/me/yukun99/ip/exceptions/HelpBotInvalidTaskTypeException.java
+++ b/src/main/java/me/yukun99/ip/exceptions/HelpBotInvalidTaskTypeException.java
@@ -15,12 +15,14 @@ public class HelpBotInvalidTaskTypeException extends HelpBotException {
      */
     public HelpBotInvalidTaskTypeException(Task.Type type) {
         super();
+        assert type != null;
         this.type = type;
     }
 
     @Override
     public String toString() {
         return super.toString()
-                + "\nThe operation could not be performed on task type: " + type.toString().toLowerCase();
+                + System.lineSeparator() + "The operation could not be performed on task type: "
+                + type.toString().toLowerCase();
     }
 }


### PR DESCRIPTION
Right now, we do not check if our Task Type is not null in our HelpBotInvalidTaskTypeException. This could lead to users being confused if I make a mistake of creating a task without the right type.

To fix this, we assert `type != null` in the constructor to make sure that this forces the application to exit instead of printing the wrong error.

This prevents confusion in the case of my error.